### PR TITLE
fix: checkpointの割当前検査・復元メモリ削減・実験予算の厳格化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           cache-dependency-path: pyproject.toml
       - run: python -m pip install -e ".[dev,neural]"
       - run: python -m pytest -q --junitxml=work/validation/junit.xml
+      - run: python scripts/check_experiment.py examples/experiment.json
       - run: python scripts/audit_release.py
       - run: python -m build
       - name: Retain test evidence even when tests fail

--- a/organism_core/checkpoint.py
+++ b/organism_core/checkpoint.py
@@ -6,6 +6,9 @@ Existing valid schema-1 checkpoints remain readable; no identity is rewritten.
 """
 from pathlib import Path
 import hashlib
+import ast
+import math
+import struct
 import json
 import os
 import re
@@ -25,6 +28,61 @@ def _unique_object(pairs):
 
 def _invalid_constant(value):
     raise ValueError('Nonfinite checkpoint JSON constant: '+value)
+
+
+def _finite_float(value):
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError('Nonfinite checkpoint JSON number')
+    return parsed
+
+
+def _preflight(archive, max_uncompressed_bytes, max_metadata_bytes):
+    """Read only small NPY headers before NumPy can allocate their declared shape.
+
+    ZIP sizes include NPY headers. No payload is extracted to the filesystem.
+    Version 1/2 headers use latin1 and version 3 uses UTF-8, per the NPY format.
+    Python integer products cannot silently overflow for a forged large shape.
+    """
+    total = sum(info.file_size for info in archive.infolist())
+    if max_uncompressed_bytes is not None and total > max_uncompressed_bytes:
+        raise ValueError('Checkpoint exceeds uncompressed byte budget')
+    for info in archive.infolist():
+        with archive.open(info) as member:
+            version = np.lib.format.read_magic(member)
+            if version not in ((1, 0), (2, 0), (3, 0)):
+                raise ValueError('Unsupported checkpoint NPY version')
+            width = 2 if version == (1, 0) else 4
+            size_bytes = member.read(width)
+            if len(size_bytes) != width:
+                raise ValueError('Truncated checkpoint NPY header')
+            size = struct.unpack('<H' if width == 2 else '<I', size_bytes)[0]
+            # Match np.load's existing default maximum header size.
+            if size > 10000:
+                raise ValueError('Checkpoint NPY header exceeds 10000 bytes')
+            raw = member.read(size)
+            if len(raw) != size:
+                raise ValueError('Truncated checkpoint NPY header')
+            try:
+                header = ast.literal_eval(raw.decode('utf-8' if version == (3, 0) else 'latin1'))
+                if (not isinstance(header, dict) or set(header) != {'shape', 'fortran_order', 'descr'}
+                        or not isinstance(header['shape'], tuple)
+                        or any(type(d) is not int or d < 0 for d in header['shape'])
+                        or type(header['fortran_order']) is not bool):
+                    raise ValueError('Invalid NPY header fields')
+                dtype = np.lib.format.descr_to_dtype(header['descr'])
+            except (ValueError, TypeError, SyntaxError, UnicodeError, RecursionError) as error:
+                raise ValueError('Invalid checkpoint NPY header') from error
+            if dtype.hasobject:
+                raise ValueError('Object arrays forbidden')
+            payload = math.prod(header['shape']) * dtype.itemsize
+            if payload != info.file_size - member.tell():
+                raise ValueError('Checkpoint NPY shape/payload size mismatch')
+            if info.filename == 'metadata.npy':
+                if header['shape'] != () or dtype.kind != 'U':
+                    raise ValueError('Checkpoint metadata must be a Unicode scalar')
+                if info.file_size > max_metadata_bytes:
+                    raise ValueError('Checkpoint metadata exceeds byte budget')
 
 
 def save(path, state, identity):
@@ -70,7 +128,20 @@ def save(path, state, identity):
     return {'path': str(path), 'sha256': digest}
 
 
-def load(path, identity, expected_sha256=None):
+def load(path, identity, expected_sha256=None, *, max_uncompressed_bytes=None,
+         max_metadata_bytes=16 * 1024 * 1024):
+    """Decode owned arrays; optionally bound total uncompressed ZIP bytes.
+
+    The default leaves whole-state size unrestricted for large CNS checkpoints.
+    Metadata is bounded to 16 MiB (including its NPY header), explicitly tunable.
+    This preflight is not an OS-level memory/time sandbox for hostile input.
+    """
+    for name, limit in (('max_uncompressed_bytes', max_uncompressed_bytes),
+                        ('max_metadata_bytes', max_metadata_bytes)):
+        if limit is None and name == 'max_uncompressed_bytes':
+            continue
+        if type(limit) is not int or limit <= 0:
+            raise ValueError(name + ' must be a positive integer byte count')
     if not isinstance(identity, dict):
         raise TypeError('Checkpoint identity must be a dictionary')
     if expected_sha256 is not None and (
@@ -88,13 +159,14 @@ def load(path, identity, expected_sha256=None):
                     or any(n != 'metadata.npy' and not re.fullmatch(r'a(?:0|[1-9][0-9]*)\.npy', n)
                            for n in names)):
                 raise ValueError('Invalid or duplicate checkpoint archive members')
+            _preflight(archive, max_uncompressed_bytes, max_metadata_bytes)
         stream.seek(0)
         with np.load(stream, allow_pickle=False) as data:
             raw = data['metadata']
             if raw.shape != () or raw.dtype.kind != 'U':
                 raise ValueError('Checkpoint metadata must be a Unicode scalar')
             meta = json.loads(str(raw), object_pairs_hook=_unique_object,
-                              parse_constant=_invalid_constant)
+                              parse_constant=_invalid_constant, parse_float=_finite_float)
             if (not isinstance(meta, dict) or set(meta) != {'schema', 'identity', 'tree'}
                     or type(meta['schema']) is not int or meta['schema'] != 1
                     or not isinstance(meta['identity'], dict)):
@@ -114,7 +186,9 @@ def load(path, identity, expected_sha256=None):
                             or value not in data.files or value in used):
                         raise ValueError('Invalid or repeated checkpoint array reference')
                     used.add(value)
-                    return data[value].copy()
+                    # NpzFile materializes a fresh owned array on every access.
+                    # Avoid a second full-state array allocation during restore.
+                    return data[value]
                 if tag == 'scalar':
                     if value is not None and type(value) not in (bool, int, float, str):
                         raise ValueError('Invalid checkpoint scalar')

--- a/scripts/check_experiment.py
+++ b/scripts/check_experiment.py
@@ -1,18 +1,108 @@
-"""Validate the minimal structure of an experiment record, not its scientific truth."""
-import argparse,json
+"""Validate an experiment record's structure, not its scientific truth."""
+import argparse
+import json
+import math
 from pathlib import Path
-def validate(record):
-    for key in ('schema_version','kind','status','question','hypothesis','seed','units','budget','controls','success_criterion','falsification','evidence','biological_validation'):
-        if key not in record:raise ValueError('Missing '+key)
-    if record['schema_version']!=1:raise ValueError('Unknown schema')
-    if record['kind'] not in ('synthetic','reference','organism_candidate'):raise ValueError('Unknown experiment kind')
-    if record['status'] not in ('planned','completed','failed'):raise ValueError('Unknown status')
-    if record['budget']['wall_seconds']<=0 or record['budget']['memory_mib']<=0:raise ValueError('Positive resource budget required')
-    if record['status']=='completed' and not record['evidence']:raise ValueError('Completed experiment needs evidence locators')
-    if record['kind']=='synthetic' and record['biological_validation']:raise ValueError('Synthetic experiment cannot claim biological validation')
-def main():
-    p=argparse.ArgumentParser();p.add_argument('record',type=Path);args=p.parse_args()
-    validate(json.loads(args.record.read_text(encoding='utf-8')))
-    print('Structure valid; evidence and scientific claims require review.')
-if __name__=='__main__':main()
 
+
+def _text(value):
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _json_values(value, depth=0):
+    if depth > 100:
+        raise ValueError('Experiment record nesting exceeds 100 levels')
+    if type(value) is float and not math.isfinite(value):
+        raise ValueError('Finite JSON numbers required')
+    if value is None or type(value) in (str, bool, int, float):
+        return
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        children = value.values()
+    elif isinstance(value, list):
+        children = value
+    else:
+        raise ValueError('JSON-compatible values and string keys required')
+    for child in children:
+        _json_values(child, depth + 1)
+
+
+def validate(record):
+    if not isinstance(record, dict):
+        raise ValueError('Experiment record must be an object')
+    _json_values(record)
+    required = ('schema_version', 'kind', 'status', 'question', 'hypothesis', 'seed',
+                'units', 'budget', 'controls', 'success_criterion', 'falsification',
+                'evidence', 'biological_validation')
+    for key in required:
+        if key not in record:
+            raise ValueError('Missing ' + key)
+    if type(record['schema_version']) is not int or record['schema_version'] != 1:
+        raise ValueError('Unknown schema')
+    if record['kind'] not in ('synthetic', 'reference', 'organism_candidate'):
+        raise ValueError('Unknown experiment kind')
+    if record['status'] not in ('planned', 'completed', 'failed'):
+        raise ValueError('Unknown status')
+    for key in ('question', 'hypothesis', 'success_criterion', 'falsification'):
+        if not _text(record[key]):
+            raise ValueError(key + ' must be nonempty text')
+    if type(record['seed']) is not int or record['seed'] < 0:
+        raise ValueError('Nonnegative integer seed required')
+    units = record['units']
+    if not (_text(units) or (isinstance(units, dict) and units
+                            and all(_text(k) and _text(v) for k, v in units.items()))):
+        raise ValueError('Named units or a nonempty unit description required')
+    budget = record['budget']
+    if not isinstance(budget, dict):
+        raise ValueError('Resource budget must be an object')
+    for key in ('wall_seconds', 'memory_mib'):
+        value = budget.get(key)
+        try:
+            valid = type(value) in (int, float) and math.isfinite(value) and value > 0
+        except OverflowError:
+            valid = False
+        if not valid:
+            raise ValueError('Positive finite numeric resource budget required: ' + key)
+    controls = record['controls']
+    if not isinstance(controls, list) or not controls or not all(_text(c) for c in controls):
+        raise ValueError('Nonempty control descriptions required')
+    evidence = record['evidence']
+    if (not isinstance(evidence, list)
+            or not all(_text(e) or (isinstance(e, dict) and bool(e)) for e in evidence)):
+        raise ValueError('Evidence must be a list of nonempty locators or structured references')
+    if record['status'] == 'completed' and not evidence:
+        raise ValueError('Completed experiment needs evidence locators')
+    if type(record['biological_validation']) is not bool:
+        raise ValueError('biological_validation must be a boolean')
+    if record['kind'] == 'synthetic' and record['biological_validation']:
+        raise ValueError('Synthetic experiment cannot claim biological validation')
+
+
+def _unique_object(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError('Duplicate experiment JSON key: ' + key)
+        result[key] = value
+    return result
+
+
+def read_record(path):
+    record = json.loads(Path(path).read_text(encoding='utf-8'), object_pairs_hook=_unique_object)
+    validate(record)
+    return record
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('record', type=Path, nargs='+')
+    args = parser.parse_args()
+    try:
+        for path in args.record:
+            read_record(path)
+    except (OSError, ValueError, RecursionError) as error:
+        parser.error(str(error))
+    print('Structure valid; evidence and scientific claims require review.')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/unit/test_checkpoint_preflight.py
+++ b/tests/unit/test_checkpoint_preflight.py
@@ -1,0 +1,102 @@
+"""Bounded fixtures exercise allocation guards; no large array is allocated."""
+import io
+import json
+import struct
+import zipfile
+import numpy as np
+import pytest
+from organism_core import checkpoint as codec
+
+
+def write_archive(path, payload, *, metadata=None):
+    meta = io.BytesIO()
+    np.save(meta, np.array(metadata or json.dumps(
+        {'schema': 1, 'identity': {}, 'tree': {'array': 'a0'}})))
+    with zipfile.ZipFile(path, 'w', compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr('metadata.npy', meta.getvalue())
+        archive.writestr('a0.npy', payload)
+    return path
+
+
+def npy_header(shape, descr='<f8', version=(1, 0), payload=b''):
+    header = repr({'shape': shape, 'fortran_order': False, 'descr': descr}) + '\n'
+    raw = header.encode('utf-8' if version == (3, 0) else 'latin1')
+    width = '<H' if version == (1, 0) else '<I'
+    return b'\x93NUMPY' + bytes(version) + struct.pack(width, len(raw)) + raw + payload
+
+
+@pytest.mark.parametrize('shape,payload', [((10**15,), b''), ((2,), b'12345678'),
+    ((1,), b'x'*16), ((2**63, 2**63), b''), ((-1,), b''), ((True,), b'')])
+def test_bad_shape_or_payload_is_rejected_before_numpy_load(tmp_path, monkeypatch, shape, payload):
+    path = write_archive(tmp_path/'bad.npz', npy_header(shape, payload=payload))
+    def forbidden(*args, **kwargs):
+        raise AssertionError('np.load must not receive a forged allocation')
+    monkeypatch.setattr(codec.np, 'load', forbidden)
+    with pytest.raises(ValueError):
+        codec.load(path, {})
+
+
+@pytest.mark.parametrize('payload', [b'\x93NUMPY\x01\x00\x01',
+    b'\x93NUMPY\x01\x00\xff\xff', b'\x93NUMPY\x01\x00\x08\x00x',
+    npy_header((1,), '|O', payload=b'12345678'), npy_header((1,), version=(4, 0))])
+def test_invalid_header_rejected(tmp_path, payload):
+    with pytest.raises(ValueError):
+        codec.load(write_archive(tmp_path/'bad.npz', payload), {})
+
+
+@pytest.mark.parametrize('version', [(1, 0), (2, 0), (3, 0)])
+def test_supported_npy_versions(tmp_path, version):
+    array = np.arange(6, dtype='>i4').reshape(2, 3)
+    stream = io.BytesIO(); np.lib.format.write_array(stream, array, version=version)
+    actual = codec.load(write_archive(tmp_path/'ok.npz', stream.getvalue()), {})
+    np.testing.assert_array_equal(actual, array)
+    assert actual.dtype == array.dtype
+
+
+def test_unicode_structured_npy_v3(tmp_path):
+    array = np.zeros(3, dtype=[('角度', '<f8'), ('joint', '<i4')])
+    stream = io.BytesIO(); np.lib.format.write_array(stream, array, version=(3, 0))
+    actual = codec.load(write_archive(tmp_path/'ok.npz', stream.getvalue()), {})
+    np.testing.assert_array_equal(actual, array)
+    assert actual.dtype == array.dtype
+
+
+@pytest.mark.parametrize('value', ['1e999', '-1e999', 'NaN', 'Infinity', '-Infinity'])
+def test_json_overflow_never_becomes_checkpoint_state(tmp_path, value):
+    path = tmp_path/'bad.npz'
+    np.savez(path, metadata=np.array('{"schema":1,"identity":{},"tree":{"scalar":' + value + '}}'))
+    with pytest.raises(ValueError, match='Nonfinite'):
+        codec.load(path, {})
+
+
+@pytest.mark.parametrize('name', ['max_uncompressed_bytes', 'max_metadata_bytes'])
+@pytest.mark.parametrize('limit', [0, -1, True, 1.5, float('inf'), '1000'])
+def test_invalid_resource_limits(tmp_path, name, limit):
+    with pytest.raises(ValueError, match='positive integer'):
+        codec.load(tmp_path/'unused', {}, **{name: limit})
+
+
+def test_byte_budgets_include_headers_and_metadata(tmp_path, monkeypatch):
+    path = tmp_path/'state.npz'; receipt = codec.save(path, {'x': np.zeros(100)}, {})
+    with zipfile.ZipFile(path) as archive:
+        total = sum(info.file_size for info in archive.infolist())
+        meta = archive.getinfo('metadata.npy').file_size
+    codec.load(path, {}, receipt['sha256'], max_uncompressed_bytes=total, max_metadata_bytes=meta)
+    for kwargs in ({'max_uncompressed_bytes': total-1}, {'max_metadata_bytes': meta-1}):
+        with pytest.raises(ValueError, match='byte budget'):
+            codec.load(path, {}, **kwargs)
+
+
+@pytest.mark.parametrize('array', [np.arange(5), np.zeros((0, 3)), np.array(3.25),
+    np.asfortranarray(np.arange(12).reshape(3, 4)), np.array(['日本語', 'fly']),
+    np.array(['2026-09-11'], dtype='datetime64[D]')])
+def test_restored_arrays_survive_close_and_do_not_alias_disk(tmp_path, array):
+    path = tmp_path/'state.npz'; receipt = codec.save(path, {'x': array}, {})
+    first = codec.load(path, {}, receipt['sha256'])['x']
+    second = codec.load(path, {}, receipt['sha256'])['x']
+    np.testing.assert_array_equal(first, array)
+    assert first.flags.writeable
+    assert not np.shares_memory(first, second)
+    if first.size:
+        first.reshape(-1)[0] = first.reshape(-1)[-1]
+    np.testing.assert_array_equal(codec.load(path, {}, receipt['sha256'])['x'], array)

--- a/tests/unit/test_experiment_contract.py
+++ b/tests/unit/test_experiment_contract.py
@@ -1,0 +1,81 @@
+"""Malformed records must not bypass declared experiment resource budgets."""
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+import pytest
+from scripts.check_experiment import validate, read_record
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def example():
+    return json.loads((ROOT/'examples/experiment.json').read_text(encoding='utf-8'))
+
+
+@pytest.mark.parametrize('field', ['wall_seconds', 'memory_mib'])
+@pytest.mark.parametrize('bad', [float('nan'), float('inf'), -float('inf'), True,
+    False, 0, -1, '60', None, [], {}, 10**1000])
+def test_invalid_budgets(field, bad):
+    record = example(); record['budget'][field] = bad
+    with pytest.raises(ValueError): validate(record)
+
+
+@pytest.mark.parametrize('key,bad', [('schema_version', True), ('schema_version', 1.),
+    ('seed', True), ('seed', -1), ('seed', 0.), ('question', ''), ('hypothesis', ' '),
+    ('success_criterion', None), ('falsification', []), ('units', {}), ('units', []),
+    ('units', {'time': ''}), ('budget', None), ('controls', 'control'), ('controls', []),
+    ('controls', ['']), ('evidence', 'proof'), ('evidence', [None]), ('evidence', [{}]),
+    ('biological_validation', 0), ('biological_validation', 'false')])
+def test_strict_field_types(key, bad):
+    record = example(); record[key] = bad
+    with pytest.raises(ValueError): validate(record)
+
+
+@pytest.mark.parametrize('record', [None, [], 1, 'record'])
+def test_top_level_object_required(record):
+    with pytest.raises(ValueError): validate(record)
+
+
+def test_missing_budget_field_is_validation_error():
+    record = example(); del record['budget']['memory_mib']
+    with pytest.raises(ValueError): validate(record)
+
+
+def test_nonfinite_extra_parameters_rejected():
+    record = example(); record['parameters'] = {'x': [float('nan')]}
+    with pytest.raises(ValueError): validate(record)
+
+
+def test_duplicate_json_key_rejected(tmp_path):
+    path = tmp_path/'record.json'
+    text = json.dumps(example()).replace('"seed": 0', '"seed": 0, "seed": 1')
+    path.write_text(text, encoding='utf-8')
+    with pytest.raises(ValueError, match='Duplicate'): read_record(path)
+
+
+def test_valid_completed_record_and_structured_evidence():
+    record = example(); record['status'] = 'completed'
+    record['evidence'] = ['work/run/result.json', {'path': 'work/run/observations.npz'}]
+    before = copy.deepcopy(record); validate(record); assert record == before
+
+
+def test_published_examples_and_multiple_file_cli():
+    paths = sorted((ROOT/'examples').glob('*.json'))
+    for path in paths: read_record(path)
+    result = subprocess.run([sys.executable, str(ROOT/'scripts/check_experiment.py'),
+                             *map(str, paths)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+def test_cli_rejects_overflow_budget_without_traceback(tmp_path):
+    path = tmp_path/'bad.json'; path.write_text(json.dumps(example()).replace('60', '1e999'), encoding='utf-8')
+    result = subprocess.run([sys.executable, str(ROOT/'scripts/check_experiment.py'), str(path)], capture_output=True, text=True)
+    assert result.returncode == 2 and 'Finite JSON' in result.stderr
+    assert 'Traceback' not in result.stderr
+
+
+def test_cyclic_or_excessively_deep_record_rejected():
+    record = example(); record['cycle'] = record
+    with pytest.raises(ValueError, match='nesting'): validate(record)


### PR DESCRIPTION
## 範囲
PR #18 `c1926e1821fa53699a44d359b00afcc8de0ae1af` 基点の追加修正。5ファイル、1コミット `993ae7bb838aa4cf613189e1fe671cd86ef376ba`。身体研究や生物学的受入条件とは独立です。mainへの直接push/mergeはしていません。

## 再現した問題と修正
- `1e999` のJSON値がcheckpoint復元時に `inf` になることを実際に再現。NaN/Infinityの定数だけでなく、数値のオーバーフローも拒否します。
- NPYヘッダーのshapeから配列を確保する前に、ZIP内の実ペイロード長とPython整数で照合。切断・余剰バイト・巨大/負/真偽値shape・object型・ヘッダー異常を小さいfixtureで拒否します。NPY 1/2/3、Unicode構造化型、Fortran配置、byte order、空配列をテスト。
- `max_uncompressed_bytes` をkeyword-onlyで任意指定可能。全CNSとの互換性のため全状態サイズは既定で無制限、metadataのみ既定16MiB（ヘッダーを含み変更可能）。OS-levelのメモリ/時間sandboxではありません。
- npz読込は既に新しい所有配列を返すため、直後の不要な `.copy()` を削除。ファイル閉鎖後の利用、再読込との非共有・原ファイル不変を検証。
- 実験validatorがNaN/無限大/真偽値の予算、boolean schema、非boolean biological flag等を受け入れる問題を修正。重複JSONキー、空条件、誤った型、循環/過深構造、float変換不能な巨大予算も拒否。複数JSONを一括検査でき、CLI失敗はexit 2。追加フィールドは保持。構造検査であり、証拠の科学的真実性の認定ではありません。
- 既存CIの4matrixを維持し、公開実験例の検査を追加。

## 実施したローカル検証
Python 3.13.5 / NumPy 2.3.5。**145 passed、backend依存1module skipped**。新規95件（checkpoint39 + experiment56）。公開境界監査成功。ローカルにBrian2はなく、synthetic neural resumeはこの場では未実行。CIのPython3.11/3.12 + pinned NumPy/Brian2の結果は、最新headに対して別途確認します。過去PRの緑を流用しません。

## 再現可能なメモリ測定（合成fixture）
seed0の200万float64（16,000,000bytes）をnpz保存し、別processで旧/新各3回ロード。`tracemalloc` peakは旧 **32,017,825 bytes**、新 **17,121,140 bytes**。約46.5%減。これはこの復元処理のPython/NumPy追跡割当であり、OS RSS/全CNS全体のメモリ削減率ではありません。
全6回の復元配列SHA256は `1dd2ab8fc64d2608393bb771fb921585406ba41343fadaa9a5c01b46f755e909` で一致。時間はファイルcache等の影響があり、性能保証やCI閾値には使用しません。

## 保護条件
brain/graph lock/実神経ID・配線・重み、ACCEPTANCE、身体、筋腱、既存実験・原データ/メッシュ/保存済みcheckpointは変更なし。schema1・identity・保存形式・同一descriptorのハッシュ検査・atomic置換は維持。

## 一次仕様
NumPy NPY format: https://numpy.org/doc/2.2/reference/generated/numpy.lib.format.html
Python JSON: https://docs.python.org/3/library/json.html